### PR TITLE
Potential fix for code scanning alert no. 59: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "vscode-regexpp": "^3.1.0",
     "vscode-textmate": "9.2.0",
     "yauzl": "^3.0.0",
-    "yazl": "^2.4.3"
+    "yazl": "^2.4.3",
+    "dompurify": "^3.2.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/59](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/59)

To fix the issue, we need to ensure that any HTML content assigned to `innerHTML` is sanitized to prevent XSS attacks. This can be achieved by:
1. Using a robust HTML sanitization library, such as `DOMPurify`, to clean the `content.htmlContent` before assigning it to `innerHTML`.
2. Retaining the use of `ttPolicy?.createHTML` for compatibility with Trusted Types, but only after sanitizing the content.

The changes will be made in the `render` method where `content.htmlContent` is processed. Specifically:
- Import a sanitization library like `DOMPurify`.
- Sanitize `content.htmlContent` before passing it to `ttPolicy?.createHTML`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
