### PR TITLE
Potential fix for code scanning alert no. 52: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/src/vs/platform/languagePacks/node/languagePacks.ts
+++ b/src/vs/platform/languagePacks/node/languagePacks.ts
@@ -170,11 +170,11 @@ class LanguagePacksCache extends Disposable {
 
 	private updateHash(languagePack: ILanguagePack): void {
 		if (languagePack) {
-			const md5 = createHash('md5'); // CodeQL [SM04514] Used to create an hash for language pack extension version, which is not a security issue
+			const sha256 = createHash('sha256'); // Updated to use SHA-256 for stronger hashing
 			for (const extension of languagePack.extensions) {
-				md5.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version); // CodeQL [SM01510] The extension UUID is not sensitive info and is not manually created by a user
+				sha256.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version); // The extension UUID is not sensitive info and is not manually created by a user
 			}
-			languagePack.hash = md5.digest('hex');
+			languagePack.hash = sha256.digest('hex');
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/52](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/52)

To address the issue, we will replace the use of the MD5 hashing algorithm with SHA-256. This involves updating the call to `createHash('md5')` on line 173 to use `createHash('sha256')`. The rest of the logic for updating the hash remains unchanged, as SHA-256 is a drop-in replacement for MD5 in this context.

No additional imports or dependencies are required, as the `crypto` module in Node.js already supports SHA-256.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
