### PR TITLE
Potential fix for code scanning alert no. 38: Incomplete string escaping or encoding

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/jsDocCompletions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/jsDocCompletions.ts
@@ -103,6 +103,7 @@ class JsDocCompletionProvider implements vscode.CompletionItemProvider {
 export function templateToSnippet(template: string): vscode.SnippetString {
 	// TODO: use append placeholder
 	let snippetIndex = 1;
+	template = template.replace(/\\/g, '\\\\'); // Escape backslashes
 	template = template.replace(/\$/g, '\\$'); // CodeQL [SM02383] This is only used for text which is put into the editor. It is not for rendered html
 	template = template.replace(/^[ \t]*(?=(\/|[ ]\*))/gm, '');
 	template = template.replace(/^(\/\*\*\s*\*[ ]*)$/m, (x) => x + `\$0`);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/38](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/38)

To fix the issue, we need to ensure that backslashes in the `template` string are properly escaped. This can be achieved by adding a `replace` call to escape backslashes (`\`) before escaping dollar signs (`$`). The escaping should use a regular expression with the global (`g`) flag to ensure all occurrences are replaced.

The updated code will:
1. Escape backslashes (`\`) by replacing them with double backslashes (`\\`).
2. Escape dollar signs (`$`) as before.

The changes will be made in the `templateToSnippet` function, specifically before the existing `template.replace(/\$/g, '\\$')` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
