### PR TITLE
Potential fix for code scanning alert no. 57: Client-side cross-site scripting

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -2433,7 +2433,8 @@ async function webviewPreloads(ctx: PreloadContext) {
 			if (!el) {
 				return;
 			}
-			const trustedHtml = ttPolicy?.createHTML(html) ?? html;
+			const sanitizedHtml = DOMPurify.sanitize(html);
+			const trustedHtml = ttPolicy?.createHTML(sanitizedHtml) ?? sanitizedHtml;
 			el.innerHTML = trustedHtml as string; // CodeQL [SM03712] The rendered content comes from VS Code's tokenizer and is considered safe
 			const root = el.getRootNode();
 			if (root instanceof ShadowRoot) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/57](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/57)

To fix the issue, we need to sanitize the `html` input before it is passed to `ttPolicy.createHTML` or assigned to `el.innerHTML`. A library like `DOMPurify` can be used to sanitize the input, ensuring that only safe HTML is rendered. This approach will prevent malicious scripts from being executed.

- Modify the `MarkdownCodeBlock.highlightCodeBlock` method to sanitize the `html` parameter using `DOMPurify.sanitize`.
- Ensure that the sanitized HTML is passed to `ttPolicy.createHTML` or directly assigned to `el.innerHTML`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
