### PR TITLE
Potential fix for code scanning alert no. 44: Incomplete string escaping or encoding

### DIFF
--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -240,7 +240,7 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 					spawnOptions.shell = true;
 					spawnCommand = `"${command}"`;
 					spawnArgs = args.map(a => {
-						a = a.replace(/"/g, '\\"'); // Escape existing double quotes with \
+						a = a.replace(/\\/g, '\\\\').replace(/"/g, '\\"'); // Escape backslashes and double quotes
 						// Wrap in double quotes
 						return `"${a}"`;
 					});


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/44](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/44)

To fix the issue, we need to ensure that backslashes are escaped before escaping double quotes. This can be achieved by first replacing all backslashes (`\`) with double backslashes (`\\`), and then replacing double quotes (`"`) with escaped double quotes (`\"`). This two-step process ensures that all backslashes are properly escaped before handling other characters.

The updated code will use two `replace` calls in sequence or a single `replace` with a regular expression that handles both backslashes and double quotes. This ensures that all occurrences are replaced globally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
