### PR TITLE
Potential fix for code scanning alert no. 39: Incomplete string escaping or encoding

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
@@ -210,7 +210,7 @@ function convertLinkTags(
 }
 
 function escapeMarkdownSyntaxTokensForCode(text: string): string {
-	return text.replace(/`/g, '\\$&'); // CodeQL [SM02383] This is only meant to escape backticks. The Markdown is fully sanitized after being rendered.
+	return text.replace(/\\/g, '\\\\').replace(/`/g, '\\$&'); // Escapes backslashes and backticks for Markdown.
 }
 
 export function tagsToMarkdown(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/39](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/39)

To fix the issue, the `escapeMarkdownSyntaxTokensForCode` function should be updated to escape backslashes (`\`) in addition to backticks. This can be achieved by using a regular expression with the `g` flag to replace all occurrences of backslashes with double backslashes (`\\`). The function should then replace backticks as it currently does. This ensures that both backslashes and backticks are properly escaped for Markdown.

The updated function will:
1. Replace all backslashes (`\`) with double backslashes (`\\`).
2. Replace all backticks (`\``) with escaped backticks (`\``).

No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
