### PR TITLE
Potential fix for code scanning alert no. 34: Bad HTML filtering regexp

### DIFF
--- a/src/vs/editor/test/common/modes/supports/indentationRules.ts
+++ b/src/vs/editor/test/common/modes/supports/indentationRules.ts
@@ -27,7 +27,7 @@ export const goIndentationRules = {
 };
 
 export const htmlIndentationRules = {
-	decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/,
+	decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|--!?>|\})/,
 	increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/34](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/34)

To fix the issue, the regular expression should be updated to account for both `-->` and `--!>` as valid HTML comment end tags. This can be achieved by modifying the regex to include an optional `!` before the `>` in the comment end tag pattern. The updated regex will ensure that both forms are correctly matched.

The specific change will be made to the `decreaseIndentPattern` in the `htmlIndentationRules` object on line 30. The pattern `-->` will be replaced with `--!?>` to match both `-->` and `--!>`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
