### PR TITLE
Potential fix for code scanning alert no. 25: Useless regular-expression character escape

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
@@ -174,7 +174,7 @@ suite('Terminal Contrib Suggest Recordings', () => {
 									});
 								}
 							}));
-						} else if (event.data.match('\x1b\]633;Completions;.+\[.+\]')) {
+						} else if (event.data.match('\x1b]633;Completions;.+\[.+\]')) {
 							// If the output contains a pwsh completions sequence with results, wait for the associated
 							// suggest addon event until proceeding.
 							promises.push(new Promise<void>(r => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/25](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/25)

To fix the issue, the unnecessary escape sequence `\]` should be replaced with the literal character `]` in the regular expression. This change ensures that the regular expression is written clearly and concisely without altering its functionality. The updated regular expression will still match the intended pattern.

The change should be made on line 177 of the file `src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
