### PR TITLE
Potential fix for code scanning alert no. 27: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "vscode-textmate": "9.2.0",
     "yauzl": "^3.0.0",
     "yazl": "^2.4.3",
-    "dompurify": "^3.2.5"
+    "dompurify": "^3.2.5",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",

--- a/src/vs/base/common/marshalling.ts
+++ b/src/vs/base/common/marshalling.ts
@@ -6,6 +6,7 @@
 import { VSBuffer } from './buffer.js';
 import { URI, UriComponents } from './uri.js';
 import { MarshalledId } from './marshallingIds.js';
+import _ from 'lodash';
 
 export function stringify(obj: any): string {
 	return JSON.stringify(obj, replacer);
@@ -51,7 +52,10 @@ export function revive<T = any>(obj: any, depth = 0): Revived<T> {
 
 		switch ((<MarshalledObject>obj).$mid) {
 			case MarshalledId.Uri: return <any>URI.revive(obj);
-			case MarshalledId.Regexp: return <any>new RegExp(obj.source, obj.flags);
+			case MarshalledId.Regexp: {
+				const safeSource = _.escapeRegExp(obj.source);
+				return <any>new RegExp(safeSource, obj.flags);
+			}
 			case MarshalledId.Date: return <any>new Date(obj.source);
 		}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/27](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/27)

To fix the issue, we need to sanitize the `source` property of the object before using it to construct a `RegExp`. This can be achieved by escaping any special characters in the `source` string that have special meaning in regular expressions. A utility function like `_.escapeRegExp` from the `lodash` library can be used for this purpose.

The fix involves:
1. Importing the `lodash` library in `src/vs/base/common/marshalling.ts`.
2. Escaping the `obj.source` string using `_.escapeRegExp` before passing it to the `RegExp` constructor in the `MarshalledId.Regexp` case of the `revive` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
