### PR TITLE
Potential fix for code scanning alert no. 22: Useless regular-expression character escape

### DIFF
--- a/extensions/json/build/update-grammars.js
+++ b/extensions/json/build/update-grammars.js
@@ -9,7 +9,7 @@ var updateGrammar = require('vscode-grammar-updater');
 function adaptJSON(grammar, name, replacementScope, replaceeScope = 'json') {
 	grammar.name = name;
 	grammar.scopeName = `source${replacementScope}`;
-	const regex = new RegExp(`\.${replaceeScope}`, 'g');
+	const regex = new RegExp(`\\.${replaceeScope}`, 'g');
 	var fixScopeNames = function (rule) {
 		if (typeof rule.name === 'string') {
 			rule.name = rule.name.replace(regex, replacementScope);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/22](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/22)

To fix the issue, we need to ensure that the regular expression behaves as intended. If the goal is to match a literal period (`.`), the escape sequence should be corrected to `\\.` in the string literal. This ensures that the resulting regular expression matches a literal period. If the goal is to match any character, the backslash should be removed, leaving just `.`.

In this case, based on the context of the code, it seems the intention is to match a literal period (`.`) in the scope name. Therefore, the escape sequence should be corrected to `\\.`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
