### PR TITLE
Potential fix for code scanning alert no. 51: Information exposure through a stack trace

### DIFF
--- a/src/vs/workbench/api/node/extHostCLIServer.ts
+++ b/src/vs/workbench/api/node/extHostCLIServer.ts
@@ -112,8 +112,8 @@ export class CLIServerBase {
 				}
 				sendResponse(200, returnObj);
 			} catch (e) {
-				const message = e instanceof Error ? e.message : JSON.stringify(e);
-				sendResponse(500, message);
+				const genericMessage = "An internal server error occurred.";
+				sendResponse(500, genericMessage);
 				this.logService.error('Error while processing pipe request', e);
 			}
 		});


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/51](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/51)

To fix the issue, we need to ensure that detailed error information, such as stack traces or error messages, is not sent to the client. Instead, a generic error message should be returned to the client, while the detailed error information is logged on the server for debugging purposes. Specifically:
1. Replace the `message` variable in the `sendResponse` call on line 116 with a generic error message like `"An internal server error occurred."`.
2. Ensure that the detailed error information (`e`) is logged using `this.logService.error` for server-side debugging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
