### PR TITLE
Potential fix for code scanning alert no. 14: Inefficient regular expression

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/snippets.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/snippets.ts
@@ -7,7 +7,7 @@
  * Resolves variables in a VS Code snippet style string
  */
 export function resolveSnippet(snippetString: string, vars: ReadonlyMap<string, string>): string {
-	return snippetString.replaceAll(/(?<escape>\\\$)|(?<!\\)\$\{(?<name>\w+)(?:\/(?<pattern>(?:\\\/|[^\}])+?)\/(?<replacement>(?:\\\/|[^\}])+?)\/)?\}/g, (match, _escape, name, pattern, replacement, _offset, _str, groups) => {
+	return snippetString.replaceAll(/(?<escape>\\\$)|(?<!\\)\$\{(?<name>\w+)(?:\/(?<pattern>(?:\\\/|[^\/\}])+?)\/(?<replacement>(?:\\\/|[^\/\}])+?)\/)?\}/g, (match, _escape, name, pattern, replacement, _offset, _str, groups) => {
 		if (groups?.['escape']) {
 			return '$';
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/14](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/14)

To fix the issue, we need to remove the ambiguity in the alternation `\\\/|[^\}]`. This can be achieved by rewriting the regex to ensure that the two branches of the alternation do not overlap. Specifically, we can replace `[^\}]` with a character class that excludes both `}` and `/`, ensuring that the first branch (`\\\/`) is only used for escaped slashes, and the second branch matches all other valid characters.

The updated regex will be `(?:\\\/|[^\/\}])+?`, which ensures that the alternation is unambiguous and avoids exponential backtracking.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
