### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 # on:
 #   push:
 #     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/9](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the minimal permissions required. Based on the provided workflow, it appears that the jobs primarily involve running tests and caching dependencies, which typically require only `contents: read`. We will add this permission at the workflow level to apply it to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
