### PR TITLE
Potential fix for code scanning alert no. 23: Useless regular-expression character escape

### DIFF
--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -69,7 +69,8 @@ export class ReplEditorInput extends NotebookEditorInput implements ICompositeNo
 		}
 
 		if (resource.scheme === 'untitled') {
-			const match = new RegExp('Untitled-(\\d+)\.').exec(resource.path);
+			// Match strings like "Untitled-123." and extract the numeric identifier
+			const match = new RegExp('Untitled-(\\d+)\\.').exec(resource.path);
 			if (match?.length === 2) {
 				return `REPL - ${match[1]}`;
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/23](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/23)

To fix the issue, we need to ensure that the regular expression correctly reflects the intended behavior. If the goal is to match a literal period (`.`), the escape sequence `\.` should remain. However, if the goal is to use the `.` as a meta-character (matching any character), the backslash should be removed. Based on the context, it seems the intention is to match a literal period, so the escape sequence should remain.

To avoid confusion, we can clarify the regular expression by adding a comment explaining its purpose. This will make the code more readable and maintainable.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
