### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,5 +1,8 @@
 name: Basic checks
 
+permissions:
+  contents: read
+
 on: workflow_dispatch
 
 # on:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/7](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the minimal permissions required. Based on the provided workflow, it appears that the jobs primarily involve reading repository contents and caching dependencies. Therefore, we will set `contents: read` as the default permission at the workflow level. If any job requires additional permissions, they can be specified individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
