### PR TITLE
Potential fix for code scanning alert no. 54: DOM text reinterpreted as HTML

### DIFF
--- a/extensions/media-preview/media/imagePreview.js
+++ b/extensions/media-preview/media/imagePreview.js
@@ -311,7 +311,18 @@
 		document.body.classList.remove('loading');
 	});
 
-	image.src = settings.src;
+	try {
+		const url = new URL(settings.src, window.location.origin);
+		if (url.protocol === 'http:' || url.protocol === 'https:') {
+			image.src = url.href;
+		} else {
+			throw new Error('Invalid URL protocol');
+		}
+	} catch (err) {
+		console.error('Invalid image source URL:', err);
+		document.body.classList.add('error');
+		document.body.classList.remove('loading');
+	}
 
 	document.querySelector('.open-file-link')?.addEventListener('click', (e) => {
 		e.preventDefault();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/54](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/54)

To fix the issue, we need to validate and sanitize the `src` value extracted from the `data-settings` attribute before assigning it to `image.src`. A good approach is to ensure that the `src` value is a valid and safe URL. This can be achieved by using the `URL` constructor to parse the `src` value and verify its origin or protocol. If the value is not valid or does not meet the expected criteria, it should be rejected or replaced with a safe default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
