### PR TITLE
Potential fix for code scanning alert no. 49: Prototype-polluting function

### DIFF
--- a/src/vs/base/common/objects.ts
+++ b/src/vs/base/common/objects.ts
@@ -93,6 +93,10 @@ export function mixin(destination: any, source: any, overwrite: boolean = true):
 
 	if (isObject(source)) {
 		Object.keys(source).forEach(key => {
+			if (key === '__proto__' || key === 'constructor') {
+				// Skip prototype-polluting properties
+				return;
+			}
 			if (key in destination) {
 				if (overwrite) {
 					if (isObject(destination[key]) && isObject(source[key])) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/49](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/49)

To fix the issue, we need to prevent the `mixin` function from copying prototype-polluting properties (`__proto__` and `constructor`) from `source` to `destination`. This can be achieved by adding a check to skip these properties during the iteration over `source`.

- Modify the loop on line 95 to skip keys that are `__proto__` or `constructor`.
- Ensure that the fix does not alter the existing functionality of the `mixin` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
