### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -1,4 +1,6 @@
 name: 'Telemetry'
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/6](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's functionality, it only needs to read the repository contents. Therefore, we will set `contents: read` as the permission. This change will ensure that the workflow adheres to the principle of least privilege and mitigates potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
