### PR TITLE
Potential fix for code scanning alert no. 56: Client-side cross-site scripting

### DIFF
--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -12,6 +12,7 @@ import throttle = require('lodash.throttle');
 import morphdom from 'morphdom';
 import type { ToWebviewMessage } from '../types/previewMessaging';
 import { isOfScheme, Schemes } from '../src/util/schemes';
+import DOMPurify from 'dompurify';
 
 let scrollDisabledCount = 0;
 
@@ -206,7 +207,8 @@ window.addEventListener('message', async event => {
 			const root = document.querySelector('.markdown-body')!;
 
 			const parser = new DOMParser();
-			const newContent = parser.parseFromString(data.content, 'text/html'); // CodeQL [SM03712] This renderers content from the workspace into the Markdown preview. Webviews (and the markdown preview) have many other security measures in place to make this safe
+			const sanitizedContent = DOMPurify.sanitize(data.content);
+			const newContent = parser.parseFromString(sanitizedContent, 'text/html'); // CodeQL [SM03712] This renderers content from the workspace into the Markdown preview. Webviews (and the markdown preview) have many other security measures in place to make this safe
 
 			// Strip out meta http-equiv tags
 			for (const metaElement of Array.from(newContent.querySelectorAll('meta'))) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/56](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/56)

To fix the issue, we need to sanitize the `data.content` before passing it to `DOMParser.parseFromString`. This can be achieved by using a well-known library like `DOMPurify` to remove potentially malicious content from the HTML string. `DOMPurify` is a widely used library for sanitizing HTML and is effective at preventing XSS attacks.

Steps to implement the fix:
1. Install the `dompurify` library as a dependency.
2. Import `DOMPurify` into the file.
3. Use `DOMPurify.sanitize` to sanitize `data.content` before parsing it with `DOMParser`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
