### PR TITLE
Potential fix for code scanning alert no. 28: Shell command built from environment values

### DIFF
--- a/build/azure-pipelines/publish-types/update-types.ts
+++ b/build/azure-pipelines/publish-types/update-types.ts
@@ -16,7 +16,7 @@ try {
 
 	const dtsUri = `https://raw.githubusercontent.com/microsoft/vscode/${tag}/src/vscode-dts/vscode.d.ts`;
 	const outPath = path.resolve(process.cwd(), 'DefinitelyTyped/types/vscode/index.d.ts');
-	cp.execSync(`curl ${dtsUri} --output ${outPath}`);
+	cp.execFileSync('curl', [dtsUri, '--output', outPath]);
 
 	updateDTSFile(outPath, tag);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/28](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/28)

To fix the issue, we should avoid dynamically constructing the shell command as a single string. Instead, we can use `cp.execFileSync`, which allows us to pass the command and its arguments separately. This approach avoids shell interpretation of special characters in the arguments, mitigating the risk of injection attacks.

Specifically:
1. Replace the `execSync` call on line 19 with `execFileSync`.
2. Pass `curl` as the command and the arguments (`dtsUri`, `--output`, and `outPath`) as an array.
3. Ensure no other functionality is altered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
