### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/no-package-lock-changes.yml
+++ b/.github/workflows/no-package-lock-changes.yml
@@ -1,4 +1,6 @@
 name: Prevent package-lock.json changes in PRs
+permissions:
+  contents: read
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/1](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it only needs to read repository contents and collaborator permissions. Therefore, we will set `contents: read` as the permission.

The `permissions` block will be added at the top level of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
