### PR TITLE
Potential fix for code scanning alert no. 50: Prototype-polluting function

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1082,6 +1082,10 @@ function applyUpdate<T>(value: T | undefined, update: T): ApplyUpdateResult<T> {
 	let didChange = false;
 	for (const key in update) {
 		if ((update as T & object).hasOwnProperty(key)) {
+			// Skip prototype-polluting keys
+			if (key === '__proto__' || key === 'constructor') {
+				continue;
+			}
 			const result = applyUpdate(value[key], update[key]);
 			if (result.didChange) {
 				value[key] = result.newValue;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/50](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/50)

To fix the issue, we need to explicitly block the special keys `__proto__` and `constructor` from being copied during the recursive property assignment. This can be achieved by adding a condition to skip these keys in the loop on line 1083. This ensures that even if the `update` object contains these keys, they will not be assigned to the `value` object.

The fix involves:
1. Adding a check to skip keys named `__proto__` or `constructor` in the loop.
2. Ensuring that the rest of the functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
