### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/no-yarn-lock-changes.yml
+++ b/.github/workflows/no-yarn-lock-changes.yml
@@ -1,5 +1,7 @@
 name: Prevent yarn.lock changes in PRs
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   main:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/5](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it only needs to read repository contents and collaborator permissions. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
