### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/monaco-editor.yml
+++ b/.github/workflows/monaco-editor.yml
@@ -1,4 +1,6 @@
 name: Monaco Editor checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/4](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to the minimum required for the workflow to function. Based on the workflow's operations, it only needs `contents: read` to access the repository's contents. No write permissions are necessary.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
