### PR TITLE
Potential fix for code scanning alert no. 66: Useless regular-expression character escape

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
@@ -174,7 +174,7 @@ suite('Terminal Contrib Suggest Recordings', () => {
 									});
 								}
 							}));
-						} else if (event.data.match('\x1b]633;Completions;.+\[.+]')) {
+						} else if (event.data.match('\x1b]633;Completions;.+[.+]')) {
 							// If the output contains a pwsh completions sequence with results, wait for the associated
 							// suggest addon event until proceeding.
 							promises.push(new Promise<void>(r => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/66](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/66)

To fix the issue, the unnecessary escape sequence `\[` should be removed from the regular expression string on line 177. The corrected string will still function as intended, as the `[` character does not need to be escaped in this context. This change will make the code cleaner and easier to understand.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
