### PR TITLE
Potential fix for code scanning alert no. 65: Bad HTML filtering regexp

### DIFF
--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -1016,7 +1016,7 @@ const paragraph = edit(_paragraph)
     .replace('blockquote', ' {0,3}>')
     .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
     .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
-    .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)>/i')
+    .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)>', 'i')
     .replace('tag', _tag) // pars can be interrupted by type (6) html blocks
     .getRegex();
 const blockquote = edit(/^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/)
@@ -1052,7 +1052,7 @@ const gfmTable = edit('^ *([^\\n ].*)\\n' // Header
     .replace('code', ' {4}[^\\n]')
     .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
     .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
-    .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
+    .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)>', 'i')
     .replace('tag', _tag) // tables can be interrupted by type (6) html blocks
     .getRegex();
 const blockGfm = {
@@ -1066,7 +1066,7 @@ const blockGfm = {
         .replace('blockquote', ' {0,3}>')
         .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
         .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
-        .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
+        .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)>', 'i')
         .replace('tag', _tag) // pars can be interrupted by type (6) html blocks
         .getRegex(),
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/65](https://github.com/Git-Hub-Chris/Visual-Studio-Code/security/code-scanning/65)

To fix the issue, we need to make the regex case-insensitive by adding the `i` flag. This ensures that the regex matches HTML tags regardless of their case (e.g., `<script>`, `<SCRIPT>`, `<ScRiPt>`). The changes should be applied to all instances of the regex where HTML tags are matched.

Specifically:
1. Update the regex on line 1019, 1055, and 1069 to include the `i` flag.
2. Ensure that the regex remains functionally equivalent while adding case-insensitivity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
